### PR TITLE
Enhance batters leaderboard table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-accordion": "^1.2.3",
+        "@radix-ui/react-checkbox": "^1.1.4",
         "@radix-ui/react-collapsible": "^1.1.3",
+        "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-slot": "^1.1.2",
         "@tanstack/react-table": "^8.21.2",
         "class-variance-authority": "^0.7.1",
@@ -876,6 +878,35 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.1.4.tgz",
+      "integrity": "sha512-wP0CPAHq+P5I4INKe3hJrIa1WoNqqrejzW+zoU0rOvo1b9gDEJJFl2rYfO1PYJUQCc2H1WZxIJmyv9BS8i5fLw==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-previous": "1.1.0",
+        "@radix-ui/react-use-size": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-collapsible": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.3.tgz",
@@ -958,6 +989,41 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.6.tgz",
+      "integrity": "sha512-/IVhJV5AceX620DUJ4uYVMymzsipdKBzo3edo+omeskCKGm9FRHM0ebIdbPnlQVJqyuHbuBltQUOG2mOTq2IYw==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.5",
+        "@radix-ui/react-focus-guards": "1.1.1",
+        "@radix-ui/react-focus-scope": "1.1.2",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-portal": "1.1.4",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-slot": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-direction": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.0.tgz",
@@ -968,6 +1034,70 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.5.tgz",
+      "integrity": "sha512-E4TywXY6UsXNRhFrECa5HAvE5/4BFcGyfTyK36gP+pAW1ed7UTK4vKwdr53gAJYwqbfCWC6ATvJa3J3R/9+Qrg==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-escape-keydown": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.1.tgz",
+      "integrity": "sha512-pSIwfrT1a6sIoDASCSpFwOasEwKTZWDw/iBdtnqKO7v6FeOzYJ7U53cPzYFVR3geGGXgVHaH+CdngrrAzqUGxg==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.2.tgz",
+      "integrity": "sha512-zxwE80FCU7lcXUGWkdt6XpTTCKPitG1XKOwViTxHVKIJhZl9MvIl2dVHeZENCWD9+EdWv05wlaEkRXUykU27RA==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -985,6 +1115,29 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.4.tgz",
+      "integrity": "sha512-sn2O9k1rPFYVyKd5LAJfo96JlSGVFpa1fS6UuBJfrZadudiw5tAmru+n1x7aMRQ84qDM71Zh1+SzK5QwU0tJfA==",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -1082,10 +1235,58 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.0.tgz",
+      "integrity": "sha512-L7vwWlR1kTTQ3oh7g1O0CBF3YCyyTj8NmhLR+phShpyA50HCfBFKVJTpshm9PzLiKmehsrQzTYTpX9HvmC9rhw==",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-layout-effect": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
       "integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.0.tgz",
+      "integrity": "sha512-Z/e78qg2YFnnXcW88A4JmTtm4ADckLno6F7OXotmkQfeuCVaKuYzqAATPhVzl3delXE7CxIV8shofPn3jPc5Og==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.0.tgz",
+      "integrity": "sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -1515,6 +1716,17 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.4.tgz",
+      "integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/aria-query": {
       "version": "5.3.2",
@@ -2143,6 +2355,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -3033,6 +3250,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-proto": {
@@ -4627,6 +4852,72 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.3.tgz",
+      "integrity": "sha512-pnAi91oOk8g8ABQKGF5/M9qxmmOPxaAnopyTHYfqYEwJhyFrbbBtHuSgtKEoH0jpcxx5o3hXqH1mNd9/Oi+8iQ==",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -5632,6 +5923,47 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.3",
+    "@radix-ui/react-checkbox": "^1.1.4",
     "@radix-ui/react-collapsible": "^1.1.3",
+    "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-slot": "^1.1.2",
     "@tanstack/react-table": "^8.21.2",
     "class-variance-authority": "^0.7.1",

--- a/src/app/hitters/columns.tsx
+++ b/src/app/hitters/columns.tsx
@@ -2,8 +2,6 @@
 
 import { ColumnDef } from "@tanstack/react-table"
 import { UserHitterSelection } from "@/lib/types/hitters"
-import { Button } from "@/components/ui/button"
-import { ChevronDown, ChevronRight } from "lucide-react"
 
 export const columns: ColumnDef<UserHitterSelection>[] = [
     {
@@ -36,18 +34,5 @@ export const columns: ColumnDef<UserHitterSelection>[] = [
         accessorKey: "eligibleOPS",
         header: "Eligible Batters' OPS",
         cell: ({ getValue }) => <span>{getValue<number>().toFixed(4)}</span>,
-    },
-    {
-        id: "expander",
-        header: () => null,
-        cell: ({ row }) => (
-            <Button
-                variant="ghost"
-                size="icon"
-                onClick={() => row.toggleExpanded()}
-            >
-                {row.getIsExpanded() ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
-            </Button>
-        ),
     },
 ]

--- a/src/app/hitters/data-table.tsx
+++ b/src/app/hitters/data-table.tsx
@@ -3,7 +3,9 @@
 import { ColumnDef, flexRender, getCoreRowModel, useReactTable, getExpandedRowModel } from "@tanstack/react-table"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { UserHitterSelection } from "@/lib/types/hitters";
+import { useState } from "react";
 import React from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
 
 interface DataTableProps {
     columns: ColumnDef<UserHitterSelection>[];
@@ -11,12 +13,18 @@ interface DataTableProps {
 }
 
 export function DataTable({ columns, data }: DataTableProps) {
+    const [expandedRow, setExpandedRow] = useState<string | null>(null)
+
     const table = useReactTable({
         data,
         columns,
         getCoreRowModel: getCoreRowModel(),
         getExpandedRowModel: getExpandedRowModel(),
     })
+
+    const handleRowClick = (rowId: string) => {
+        setExpandedRow((prevRow) => (prevRow === rowId ? null : rowId))
+    }
 
     return (
         <div className="rounded-md border">
@@ -41,47 +49,49 @@ export function DataTable({ columns, data }: DataTableProps) {
                 </TableHeader>
                 <TableBody>
                     {table.getRowModel().rows?.length ? (
-                        table.getRowModel().rows.map((row) => (
-                            <React.Fragment key={row.id}>
-                                <TableRow
-                                    key={row.id}
-                                    data-state={row.getIsSelected() && "selected"} // what does this do?
-                                >
-                                    {row.getVisibleCells().map((cell) => (
-                                        <TableCell key={cell.id}>
-                                            {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                                        </TableCell>
-                                    ))}
-                                </TableRow>
-                                {row.getIsExpanded() && (
-                                    <TableRow key={`${row.id}-expanded`}>
-                                        <TableCell colSpan={columns.length}>
-                                            <div className="p-4 bg-gray-100 rounded-md">
-                                                <h3 className="font-semibold text-lg mb-2">Selections:</h3>
-                                                <table className="w-full border-collapse border border-gray-200 rounded-md">
-                                                    <thead className="bg-gray-100">
-                                                        <tr>
-                                                            <th className="border border-gray-300 px-3 py-2 text-left">Player</th>
-                                                            <th className="border border-gray-300 px-3 py-2 text-center">AVG</th>
-                                                            <th className="border border-gray-300 px-3 py-2 text-center">OPS</th>
-                                                        </tr>
-                                                    </thead>
-                                                    <tbody>
-                                                        {(row.original.selections || []).map((selection, index) => (
-                                                            <tr key={index} className="odd:bg-white even:bg-gray-50">
-                                                                <td className="border border-gray-300 px-3 py-2">{selection.name}</td>
-                                                                <td className="border border-gray-300 px-3 py-2 text-center">{(selection.average * 1000).toFixed(1)}</td>
-                                                                <td className="border border-gray-300 px-3 py-2 text-center">{(selection.ops ?? 0).toFixed(3)}</td>
-                                                            </tr>
-                                                        ))}
-                                                    </tbody>
-                                                </table>
-                                            </div>
+                        table.getRowModel().rows.map((row) => {
+                            const isExpanded = expandedRow === row.id;
+                            return (
+                                <React.Fragment key={row.id}>
+                                    <TableRow key={row.id} onClick={() => handleRowClick(row.id)}>
+                                        {row.getVisibleCells().map((cell) => (
+                                            <TableCell key={cell.id}>
+                                                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                                            </TableCell>
+                                        ))}
+                                        <TableCell className="text-right">
+                                            {isExpanded ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
                                         </TableCell>
                                     </TableRow>
-                                )}
-                            </React.Fragment>
-                        ))
+                                    {isExpanded && (
+                                        <TableRow key={`${row.id}-expanded`}>
+                                            <TableCell colSpan={columns.length}>
+                                                <div className="p-4 bg-gray-100 rounded-md">
+                                                    <h3 className="font-semibold text-lg mb-2">Selections:</h3>
+                                                    <table className="w-full border-collapse border border-gray-200 rounded-md">
+                                                        <thead className="bg-gray-100">
+                                                            <tr>
+                                                                <th className="border border-gray-300 px-3 py-2 text-left">Player</th>
+                                                                <th className="border border-gray-300 px-3 py-2 text-center">AVG</th>
+                                                                <th className="border border-gray-300 px-3 py-2 text-center">OPS</th>
+                                                            </tr>
+                                                        </thead>
+                                                        <tbody>
+                                                            {(row.original.selections || []).map((selection, index) => (
+                                                                <tr key={index} className="odd:bg-white even:bg-gray-50">
+                                                                    <td className="border border-gray-300 px-3 py-2">{selection.name}</td>
+                                                                    <td className="border border-gray-300 px-3 py-2 text-center">{(selection.average * 1000)}</td>
+                                                                    <td className="border border-gray-300 px-3 py-2 text-center">{(selection.ops ?? 0).toFixed(3)}</td>
+                                                                </tr>
+                                                            ))}
+                                                        </tbody>
+                                                    </table>
+                                                </div>
+                                            </TableCell>
+                                        </TableRow>
+                                    )}
+                                </React.Fragment>)
+                        })
                     ) : (
                         <TableRow>
                             <TableCell colSpan={columns.length} className="h-24 text-center">

--- a/src/app/hitters/data-table.tsx
+++ b/src/app/hitters/data-table.tsx
@@ -3,9 +3,13 @@
 import { ColumnDef, flexRender, getCoreRowModel, useReactTable, getExpandedRowModel } from "@tanstack/react-table"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { UserHitterSelection } from "@/lib/types/hitters";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import React from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { DialogDescription } from "@radix-ui/react-dialog";
 
 interface DataTableProps {
     columns: ColumnDef<UserHitterSelection>[];
@@ -13,94 +17,223 @@ interface DataTableProps {
 }
 
 export function DataTable({ columns, data }: DataTableProps) {
-    const [expandedRow, setExpandedRow] = useState<string | null>(null)
+    const [expandedRow, setExpandedRow] = useState<string | null>(null);
+    const [selectedRows, setSelectedRows] = useState<Record<string, boolean>>({});
+    const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+
+    useEffect(() => {
+        console.log("Modal open state changed:", isModalOpen);
+    }, [isModalOpen]);
 
     const table = useReactTable({
         data,
         columns,
         getCoreRowModel: getCoreRowModel(),
         getExpandedRowModel: getExpandedRowModel(),
-    })
+
+    });
+
+    const handleCheckboxChange = (row: UserHitterSelection) => {
+        setSelectedRows((prevSelectedRows) => {
+            const newSelectedRows = { ...prevSelectedRows };
+
+            if (newSelectedRows[row.name]) {
+                delete newSelectedRows[row.name];
+            } else if (Object.keys(newSelectedRows).length < 5) {
+                newSelectedRows[row.name] = true;
+            }
+
+            return newSelectedRows;
+        })
+    };
+
+    const selectedUsers = Object.keys(selectedRows).filter((rowId) => selectedRows[rowId])
 
     const handleRowClick = (rowId: string) => {
         setExpandedRow((prevRow) => (prevRow === rowId ? null : rowId))
-    }
+    };
 
     return (
-        <div className="rounded-md border">
-            <Table>
-                <TableHeader>
-                    {table.getHeaderGroups().map((headerGroup) => (
-                        <TableRow key={headerGroup.id}>
-                            {headerGroup.headers.map((header) => {
+        <div>
+            <div className="mb-4 flex justify-between items-center">
+                <h2 className="text-xl font-semibold">Member Ranking For Batters</h2>
+                <Button
+                    onClick={() => setIsModalOpen(true)}
+                    disabled={Object.keys(selectedRows).length < 2}
+                    className="bg-blue-500 text-white px-4 py-2 rounded-md disabled:cursor-not-allowed disabled:opacity-50"
+                >Compare ({selectedUsers.length}) Users' Selections</Button>
+            </div>
+            <div className="rounded-md border">
+                <Table>
+                    <TableHeader>
+                        {table.getHeaderGroups().map((headerGroup) => (
+                            <TableRow key={headerGroup.id}>
+                                <TableHead className="w-10 text-center">Compare</TableHead>
+                                {headerGroup.headers.map((header) => {
+                                    return (
+                                        <TableHead key={header.id}>
+                                            {header.isPlaceholder
+                                                ? null
+                                                : flexRender(
+                                                    header.column.columnDef.header,
+                                                    header.getContext()
+                                                )}
+                                        </TableHead>
+                                    )
+                                })}
+                                <TableHead className="w-10 text-center">Show Selections</TableHead>
+                            </TableRow>
+                        ))}
+                    </TableHeader>
+                    <TableBody>
+                        {table.getRowModel().rows?.length ? (
+                            table.getRowModel().rows.map((row) => {
+                                const isExpanded = expandedRow === row.id;
+                                const isSelected = !!selectedRows[row.original.name];
+
                                 return (
-                                    <TableHead key={header.id}>
-                                        {header.isPlaceholder
-                                            ? null
-                                            : flexRender(
-                                                header.column.columnDef.header,
-                                                header.getContext()
-                                            )}
-                                    </TableHead>
-                                )
-                            })}
-                        </TableRow>
-                    ))}
-                </TableHeader>
-                <TableBody>
-                    {table.getRowModel().rows?.length ? (
-                        table.getRowModel().rows.map((row) => {
-                            const isExpanded = expandedRow === row.id;
-                            return (
-                                <React.Fragment key={row.id}>
-                                    <TableRow key={row.id} onClick={() => handleRowClick(row.id)}>
-                                        {row.getVisibleCells().map((cell) => (
-                                            <TableCell key={cell.id}>
-                                                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                                    <React.Fragment key={row.id}>
+                                        <TableRow key={row.id} onClick={(e) => e.stopPropagation()} >
+                                            <TableCell className="text-center">
+                                                <Checkbox
+                                                    checked={isSelected}
+                                                    onCheckedChange={() => handleCheckboxChange(row.original)}
+                                                    disabled={!isSelected && Object.keys(selectedRows).length >= 5}
+                                                />
                                             </TableCell>
-                                        ))}
-                                        <TableCell className="text-right">
-                                            {isExpanded ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
-                                        </TableCell>
-                                    </TableRow>
-                                    {isExpanded && (
-                                        <TableRow key={`${row.id}-expanded`}>
-                                            <TableCell colSpan={columns.length}>
-                                                <div className="p-4 bg-gray-100 rounded-md">
-                                                    <h3 className="font-semibold text-lg mb-2">Selections:</h3>
-                                                    <table className="w-full border-collapse border border-gray-200 rounded-md">
-                                                        <thead className="bg-gray-100">
-                                                            <tr>
-                                                                <th className="border border-gray-300 px-3 py-2 text-left">Player</th>
-                                                                <th className="border border-gray-300 px-3 py-2 text-center">AVG</th>
-                                                                <th className="border border-gray-300 px-3 py-2 text-center">OPS</th>
-                                                            </tr>
-                                                        </thead>
-                                                        <tbody>
-                                                            {(row.original.selections || []).map((selection, index) => (
-                                                                <tr key={index} className="odd:bg-white even:bg-gray-50">
-                                                                    <td className="border border-gray-300 px-3 py-2">{selection.name}</td>
-                                                                    <td className="border border-gray-300 px-3 py-2 text-center">{(selection.average * 1000)}</td>
-                                                                    <td className="border border-gray-300 px-3 py-2 text-center">{(selection.ops ?? 0).toFixed(3)}</td>
-                                                                </tr>
-                                                            ))}
-                                                        </tbody>
-                                                    </table>
+                                            {row.getVisibleCells().map((cell) => (
+                                                <TableCell key={cell.id}>
+                                                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                                                </TableCell>
+                                            ))}
+                                            <TableCell className="text-right pr-4 cursor-pointer hover:opacity-80" onClick={() => handleRowClick(row.id)}>
+                                                <div className="flex justify-end items-center">
+                                                    {isExpanded ? <ChevronDown size={16} className="cursor-pointer" /> : <ChevronRight size={16} className="cursor-pointer" />}
                                                 </div>
                                             </TableCell>
                                         </TableRow>
-                                    )}
-                                </React.Fragment>)
-                        })
-                    ) : (
-                        <TableRow>
-                            <TableCell colSpan={columns.length} className="h-24 text-center">
-                                No results.
-                            </TableCell>
-                        </TableRow>
-                    )}
-                </TableBody>
-            </Table>
-        </div>
+                                        {isExpanded && (
+                                            <TableRow key={`${row.id}-expanded`}>
+                                                <TableCell colSpan={columns.length}>
+                                                    <div className="p-4 bg-gray-100 rounded-md">
+                                                        <h3 className="font-semibold text-lg mb-2">Selections:</h3>
+                                                        <table className="w-full border-collapse border border-gray-200 rounded-md">
+                                                            <thead className="bg-gray-100">
+                                                                <tr>
+                                                                    <th className="border border-gray-300 px-3 py-2 text-left">Player</th>
+                                                                    <th className="border border-gray-300 px-3 py-2 text-center">AVG</th>
+                                                                    <th className="border border-gray-300 px-3 py-2 text-center">OPS</th>
+                                                                </tr>
+                                                            </thead>
+                                                            <tbody>
+                                                                {(row.original.selections || []).map((selection, index) => (
+                                                                    <tr key={index} className="odd:bg-white even:bg-gray-50">
+                                                                        <td className="border border-gray-300 px-3 py-2">{selection.name}</td>
+                                                                        <td className="border border-gray-300 px-3 py-2 text-center">{(selection.average * 1000)}</td>
+                                                                        <td className="border border-gray-300 px-3 py-2 text-center">{(selection.ops ?? 0).toFixed(3)}</td>
+                                                                    </tr>
+                                                                ))}
+                                                            </tbody>
+                                                        </table>
+                                                    </div>
+                                                </TableCell>
+                                            </TableRow>
+                                        )}
+                                    </React.Fragment>)
+                            })
+                        ) : (
+                            <TableRow>
+                                <TableCell colSpan={columns.length} className="h-24 text-center">
+                                    No results.
+                                </TableCell>
+                            </TableRow>
+                        )}
+                    </TableBody>
+                </Table>
+            </div>
+            <Dialog open={isModalOpen} onOpenChange={() => setIsModalOpen(!isModalOpen)}>
+                <DialogContent className="fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2">
+                    <DialogHeader>
+                        <DialogTitle>
+                            Compare Users' Selections
+                        </DialogTitle>
+                        <DialogDescription>Comparing selections of selected users</DialogDescription>
+                    </DialogHeader>
+                    <div className="overflow-x-auto">
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead className="text-left">Player</TableHead>
+                                    {selectedUsers.map((rowId) => {
+                                        const user = data.find((row) => row.name === rowId);
+                                        return (
+                                            <TableHead key={rowId} className="text-center">
+                                                {user?.name}
+                                            </TableHead>
+                                        );
+                                    })}
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {(() => {
+                                    // Step 1: Collect all unique player names and count occurrences
+                                    const playerSelectionCount = new Map<string, number>();
+
+                                    selectedUsers.forEach((userName) => {
+                                        const user = data.find((row) => row.name === userName);
+                                        user?.selections.forEach((sel) => {
+                                            playerSelectionCount.set(sel.name, (playerSelectionCount.get(sel.name) || 0) + 1);
+                                        });
+                                    });
+
+                                    // Step 2: Sort players by most selected first, then alphabetically
+                                    const sortedPlayers = Array.from(playerSelectionCount.keys()).sort((a, b) => {
+                                        const countA = playerSelectionCount.get(a) || 0;
+                                        const countB = playerSelectionCount.get(b) || 0;
+                                        return countB - countA || a.localeCompare(b); // Sort by count, then alphabetically
+                                    });
+
+                                    // Step 3: Render table rows
+                                    return sortedPlayers.map((playerName) => {
+                                        // Check if all users selected this player (for row highlighting)
+                                        const userSelections = selectedUsers.map((userName) => {
+                                            const user = data.find((row) => row.name === userName);
+                                            return user?.selections.find((sel) => sel.name === playerName) || null;
+                                        });
+
+                                        const hasDifferences = userSelections.some((sel => sel === null));
+
+                                        return (
+                                            <TableRow key={playerName} className={hasDifferences ? "bg-red-200" : ""}>
+                                                <TableCell className="font-medium">{playerName}</TableCell>
+                                                {selectedUsers.map((userName, index) => {
+                                                    const user = data.find((row) => row.name === userName);
+                                                    const selection = user?.selections.find((sel) => sel.name === playerName);
+
+                                                    return (
+                                                        <TableCell key={userName} className="text-center">
+                                                            {selection ? (
+                                                                <>
+                                                                    <span>AVG: {(selection.average * 1000).toFixed(0)}</span>
+                                                                    <br />
+                                                                    <span>OPS: {(selection.ops ?? 0).toFixed(3)}</span>
+                                                                </>
+                                                            ) : (
+                                                                <span className="text-gray-500">—</span>
+                                                            )}
+                                                        </TableCell>
+                                                    );
+                                                })}
+                                            </TableRow>
+                                        );
+                                    });
+                                })()}
+                            </TableBody>
+
+                        </Table>
+                    </div>
+                </DialogContent>
+            </Dialog>
+        </div >
     )
 }

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { Check } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      className
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator
+      className={cn("flex items-center justify-center text-current")}
+    >
+      <Check className="h-4 w-4" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+))
+Checkbox.displayName = CheckboxPrimitive.Root.displayName
+
+export { Checkbox }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,122 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogTrigger,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -6,9 +6,7 @@ export async function getHitterLeaderboard() {
     if (!response.ok) {
         throw new Error("Failed to fetch data");
     }
-    console.log("HITTERS");
     const data = await response.json();
-    console.log(data);
 
     const transformedData: UserHitterSelection[] = data.map((userSelection: any) =>({
         rank: userSelection["rank"],
@@ -17,8 +15,6 @@ export async function getHitterLeaderboard() {
         alternatesAvg: Number(userSelection["alternate_average"]),
         eligibleOPS: Number(userSelection["aggregate_ops"]),
         selections: userSelection["qualified_picks"].map((selection: any) => {
-            console.log("Selection Data:", selection);  // Log the full selection object
-            console.log("Selection Average Before Transformation:", selection["average"]);
     
             return {
                 name: selection["player_name"],

--- a/src/lib/hooks/hitters.ts
+++ b/src/lib/hooks/hitters.ts
@@ -14,8 +14,6 @@ export function useHitterLeaderboard() {
                     throw new Error("Failed to fetch data");
                 }
                 const data = await response.json();
-                console.log("HITTERS");
-                console.log(data);
 
                 const transformedData: UserHitterSelection[] = data.map((userSelection: any) =>({
                     rank: userSelection["rank"],


### PR DESCRIPTION
- Only allow one row to expand at a time. State management needed to do so [DONE]
- Add selecting and comparing multiple rows [DONE]

This is a prototype. Merging for now to get something functional in the main branch.

The comparison modal has problems:
- it can't scroll
- it needs to be enhanced visually to make it more readable

General problems
- When selecting a row to compare, the height of the row slightly increases