### PR TITLE
enhance search with saved filters; clean up search buttons

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -240,6 +240,7 @@ src/app/
   - Desktop: Separate container to the right of the leaderboard
 - [x] Remove Home button from navbar: Redundant since leaderboard pages have "< Back to Home"
 - [ ] (Nice-to-have) Team theme selector: Allow user to select favorite MLB team, update app color theme based on team colors
+- [ ] Filter dropdown player list: Change player selection in filter dropdown from checkbox list to table format (matching My Profile picks display style)
 - [ ] Search/filter UX improvements:
   - Always show button labels (not just on desktop)
   - Rename "My Players" to "My Picks" for clarity

--- a/src/app/core/models/index.ts
+++ b/src/app/core/models/index.ts
@@ -2,3 +2,4 @@ export * from './user.model';
 export * from './category.model';
 export * from './leaderboard.model';
 export * from './mlb-leader.model';
+export * from './saved-filter.model';

--- a/src/app/core/models/saved-filter.model.ts
+++ b/src/app/core/models/saved-filter.model.ts
@@ -1,0 +1,19 @@
+import { CategorySlug } from './category.model';
+
+/**
+ * A saved filter configuration that persists user name and player filters
+ * for quick re-application on the leaderboard.
+ */
+export interface SavedFilter {
+  readonly id: string;
+  readonly name: string;
+  readonly category: CategorySlug;
+  readonly userNameFilters: readonly string[];
+  readonly playerFilters: readonly string[];
+  readonly createdAt: number;
+}
+
+/**
+ * Storage format for saved filters, organized by category slug.
+ */
+export type SavedFiltersStorage = Partial<Record<CategorySlug, readonly SavedFilter[]>>;

--- a/src/app/core/services/filter.service.ts
+++ b/src/app/core/services/filter.service.ts
@@ -1,0 +1,127 @@
+import { Injectable, PLATFORM_ID, computed, inject, signal } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { CategorySlug, SavedFilter, SavedFiltersStorage } from '../models';
+
+const STORAGE_KEY = '300club_saved_filters';
+
+@Injectable({ providedIn: 'root' })
+export class FilterService {
+  private readonly platformId = inject(PLATFORM_ID);
+
+  // Private writable signal for all saved filters
+  private readonly _savedFilters = signal<SavedFiltersStorage>({});
+
+  // Public readonly signal
+  readonly savedFilters = this._savedFilters.asReadonly();
+
+  private get isBrowser(): boolean {
+    return isPlatformBrowser(this.platformId);
+  }
+
+  constructor() {
+    this.loadFromStorage();
+  }
+
+  /**
+   * Get saved filters for a specific category.
+   */
+  getSavedFiltersForCategory(category: CategorySlug): readonly SavedFilter[] {
+    return this._savedFilters()[category] ?? [];
+  }
+
+  /**
+   * Create a computed signal for a specific category's saved filters.
+   * Useful for reactive updates in components.
+   */
+  savedFiltersForCategory(category: CategorySlug) {
+    return computed(() => this.getSavedFiltersForCategory(category));
+  }
+
+  /**
+   * Save a new filter for a category.
+   */
+  saveFilter(
+    category: CategorySlug,
+    name: string,
+    userNameFilters: readonly string[],
+    playerFilters: readonly string[]
+  ): void {
+    const newFilter: SavedFilter = {
+      id: crypto.randomUUID(),
+      name,
+      category,
+      userNameFilters,
+      playerFilters,
+      createdAt: Date.now(),
+    };
+
+    this._savedFilters.update((current) => {
+      const categoryFilters = current[category] ?? [];
+      return {
+        ...current,
+        [category]: [...categoryFilters, newFilter],
+      };
+    });
+
+    this.persistToStorage();
+  }
+
+  /**
+   * Delete a saved filter by ID.
+   */
+  deleteFilter(category: CategorySlug, filterId: string): void {
+    this._savedFilters.update((current) => {
+      const categoryFilters = current[category] ?? [];
+      return {
+        ...current,
+        [category]: categoryFilters.filter((f) => f.id !== filterId),
+      };
+    });
+
+    this.persistToStorage();
+  }
+
+  /**
+   * Clear all saved filters for a category.
+   */
+  clearFiltersForCategory(category: CategorySlug): void {
+    this._savedFilters.update((current) => {
+      const { [category]: _, ...rest } = current;
+      return rest;
+    });
+
+    this.persistToStorage();
+  }
+
+  private loadFromStorage(): void {
+    if (!this.isBrowser) {
+      return;
+    }
+
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        const filters = JSON.parse(stored) as SavedFiltersStorage;
+        this._savedFilters.set(filters);
+      }
+    } catch {
+      try {
+        localStorage.removeItem(STORAGE_KEY);
+      } catch {
+        // Ignore storage errors
+      }
+    }
+  }
+
+  private persistToStorage(): void {
+    if (!this.isBrowser) {
+      return;
+    }
+
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(this._savedFilters()));
+    } catch {
+      // Ignore storage errors (quota exceeded, etc.)
+    }
+  }
+}

--- a/src/app/core/services/index.ts
+++ b/src/app/core/services/index.ts
@@ -2,3 +2,4 @@ export * from './user.service';
 export * from './leaderboard.service';
 export * from './theme.service';
 export * from './update.service';
+export * from './filter.service';

--- a/src/app/features/leaderboard/leaderboard.html
+++ b/src/app/features/leaderboard/leaderboard.html
@@ -14,26 +14,11 @@
       @if (category(); as cat) {
         <!-- Header -->
         <header class="mb-6">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2">
-              <h1 class="text-2xl sm:text-3xl font-bold text-club-forest">
-                {{ cat.displayName }} Leaderboard
-              </h1>
-              <app-rules-popover [category]="cat" />
-            </div>
-            <button
-              type="button"
-              (click)="openComparisonModal()"
-              class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium
-                     bg-club-sage/50 text-club-forest rounded-md
-                     hover:bg-club-sage focus:outline-none focus-visible:ring-2 focus-visible:ring-club-lime"
-            >
-              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                      d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-              </svg>
-              Compare
-            </button>
+          <div class="flex items-center gap-2">
+            <h1 class="text-2xl sm:text-3xl font-bold text-club-forest">
+              {{ cat.displayName }} Leaderboard
+            </h1>
+            <app-rules-popover [category]="cat" />
           </div>
           <p class="mt-1 text-club-gray">{{ cat.description }}</p>
         </header>
@@ -105,9 +90,9 @@
           <!-- Filter Section -->
           <div class="mb-4 space-y-3">
             <!-- Filter Controls Row -->
-            <div class="flex flex-col sm:flex-row gap-3">
+            <div class="flex flex-row items-stretch gap-2">
               <!-- User Name Search -->
-              <div class="flex-1 relative">
+              <div class="flex-1 min-w-0 relative">
                 <label for="user-search" class="sr-only">Search users (press Enter to add)</label>
                 <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-club-gray"
                      fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -119,98 +104,45 @@
                   type="text"
                   [formControl]="userSearchControl"
                   (keydown)="onUserSearchKeydown($event)"
-                  placeholder="Search users (Enter to add)..."
+                  placeholder="Search users..."
                   autocomplete="off"
-                  class="w-full pl-10 pr-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md
+                  class="w-full h-full pl-10 pr-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md
                          bg-white dark:bg-gray-800 text-club-forest dark:text-gray-100
                          focus:outline-none focus:ring-2 focus:ring-club-lime focus:border-club-lime
                          placeholder:text-gray-400"
                 />
               </div>
 
-              <!-- Filter Buttons -->
-              <div class="flex gap-2">
-                <!-- Player Filter Button -->
-                @if (cat.slug !== 'dimaggio') {
-                  <button type="button" (click)="togglePlayerDropdown()"
-                    class="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium
-                           border rounded-md transition-colors
-                           focus:outline-none focus-visible:ring-2 focus-visible:ring-club-lime"
-                    [class.bg-club-sage]="selectedPlayerFilters().size > 0"
-                    [class.border-club-green]="selectedPlayerFilters().size > 0"
-                    [class.bg-white]="selectedPlayerFilters().size === 0"
-                    [class.dark:bg-gray-800]="selectedPlayerFilters().size === 0"
-                    [class.border-gray-300]="selectedPlayerFilters().size === 0"
-                    [class.dark:border-gray-600]="selectedPlayerFilters().size === 0"
-                    [attr.aria-expanded]="showPlayerDropdown()">
-                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                            d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
-                    </svg>
-                    <span class="hidden sm:inline">Filter by Player</span>
-                    @if (selectedPlayerFilters().size > 0) {
-                      <span class="bg-club-forest text-white text-xs px-1.5 py-0.5 rounded-full">
-                        {{ selectedPlayerFilters().size }}
-                      </span>
-                    }
-                    <svg class="w-4 h-4 transition-transform duration-200"
-                         [class.rotate-180]="showPlayerDropdown()"
-                         fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-                    </svg>
-                  </button>
-                }
+              <!-- Filter Dropdown (Player filters + My Picks + Saved filters) -->
+              @if (cat.slug !== 'dimaggio') {
+                <app-filter-dropdown
+                  [category]="cat"
+                  [allPlayerNames]="allPlayerNames()"
+                  [currentUserPickNames]="currentUserPickNames()"
+                  [userNameFilters]="userNameFilters()"
+                  [selectedPlayerFilters]="selectedPlayerFilters()"
+                  [savedFilters]="savedFiltersForCategory()"
+                  (playerToggle)="togglePlayerFilter($event)"
+                  (selectMyPlayers)="selectMyPlayers()"
+                  (saveFilter)="onSaveFilter($event)"
+                  (deleteFilter)="onDeleteFilter($event)"
+                  (applyFilter)="onApplyFilter($event)"
+                />
+              }
 
-                <!-- My Players Button -->
-                @if (currentUserPickNames().length > 0 && cat.slug !== 'dimaggio') {
-                  <button type="button" (click)="selectMyPlayers()"
-                    class="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium
-                           border rounded-md transition-colors
-                           focus:outline-none focus-visible:ring-2 focus-visible:ring-club-lime"
-                    [class.bg-club-sage]="allMyPlayersSelected()"
-                    [class.border-club-green]="allMyPlayersSelected()"
-                    [class.bg-white]="!allMyPlayersSelected()"
-                    [class.dark:bg-gray-800]="!allMyPlayersSelected()"
-                    [class.border-gray-300]="!allMyPlayersSelected()"
-                    [class.dark:border-gray-600]="!allMyPlayersSelected()"
-                    [class.hover:bg-club-sage/50]="!allMyPlayersSelected()"
-                    [title]="allMyPlayersSelected() ? 'Remove my players from filter' : 'Select my players in the filter'">
-                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                            d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-                    </svg>
-                    <span class="hidden sm:inline">My Players</span>
-                  </button>
-                }
-              </div>
+              <!-- Compare Button -->
+              <button type="button" (click)="openComparisonModal()"
+                class="inline-flex items-center justify-center gap-1.5 px-2 sm:px-3 py-2 text-sm font-medium
+                       bg-club-sage/50 text-club-forest border border-club-sage rounded-md
+                       hover:bg-club-sage focus:outline-none focus-visible:ring-2 focus-visible:ring-club-lime
+                       flex-shrink-0">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                        d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+                </svg>
+                <span class="hidden sm:inline">Compare</span>
+              </button>
             </div>
-
-            <!-- Player Filter Dropdown -->
-            @if (showPlayerDropdown()) {
-              <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600
-                          rounded-lg shadow-lg p-4 max-h-64 overflow-y-auto" role="listbox"
-                   aria-label="Filter by player">
-                <input type="search" [formControl]="playerSearchControl" placeholder="Search players..."
-                  class="w-full px-3 py-2 mb-3 border border-gray-200 dark:border-gray-600 rounded-md text-sm
-                         bg-white dark:bg-gray-700 text-club-forest dark:text-gray-100
-                         focus:outline-none focus:ring-2 focus:ring-club-lime
-                         placeholder:text-gray-400" />
-                <div class="space-y-1">
-                  @for (player of filteredPlayerNames(); track player) {
-                    <label class="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-gray-50
-                                  dark:hover:bg-gray-700 cursor-pointer text-club-forest dark:text-gray-100">
-                      <input type="checkbox" [checked]="selectedPlayerFilters().has(player)"
-                        (change)="togglePlayerFilter(player)"
-                        class="rounded border-gray-300 text-club-lime focus:ring-club-lime" />
-                      <span class="text-sm">{{ player }}</span>
-                    </label>
-                  }
-                  @if (filteredPlayerNames().length === 0) {
-                    <p class="text-sm text-club-gray text-center py-2">No players found</p>
-                  }
-                </div>
-              </div>
-            }
 
             <!-- Active Filter Chips -->
             @if (hasActiveFilters()) {

--- a/src/app/features/leaderboard/leaderboard.ts
+++ b/src/app/features/leaderboard/leaderboard.ts
@@ -2,21 +2,22 @@ import { ChangeDetectionStrategy, Component, computed, effect, inject, signal, u
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { ReactiveFormsModule, FormControl } from '@angular/forms';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { map, startWith } from 'rxjs';
-import { CategorySlug, getCategoryBySlug, MlbLeader, User, UserStanding } from '../../core/models';
-import { LeaderboardService, UserService } from '../../core/services';
-import { LeagueLeadersComponent, LoadingSpinnerComponent, RulesPopoverComponent, UserComparisonModalComponent } from '../../shared/ui';
+import { map } from 'rxjs';
+import { CategorySlug, getCategoryBySlug, MlbLeader, SavedFilter, User, UserStanding } from '../../core/models';
+import { FilterService, LeaderboardService, UserService } from '../../core/services';
+import { FilterDropdownComponent, LeagueLeadersComponent, LoadingSpinnerComponent, RulesPopoverComponent, UserComparisonModalComponent } from '../../shared/ui';
 
 @Component({
   selector: 'app-leaderboard',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [RouterLink, ReactiveFormsModule, LeagueLeadersComponent, LoadingSpinnerComponent, RulesPopoverComponent, UserComparisonModalComponent],
+  imports: [RouterLink, ReactiveFormsModule, FilterDropdownComponent, LeagueLeadersComponent, LoadingSpinnerComponent, RulesPopoverComponent, UserComparisonModalComponent],
   templateUrl: './leaderboard.html',
 })
 export class LeaderboardComponent {
   private readonly route = inject(ActivatedRoute);
   private readonly leaderboardService = inject(LeaderboardService);
   private readonly userService = inject(UserService);
+  private readonly filterService = inject(FilterService);
 
   protected readonly isLoading = signal(false);
   protected readonly error = signal<string | null>(null);
@@ -32,11 +33,18 @@ export class LeaderboardComponent {
   // Filter state
   protected readonly userNameFilters = signal<string[]>([]);
   protected readonly selectedPlayerFilters = signal<Set<string>>(new Set());
-  protected readonly showPlayerDropdown = signal(false);
 
-  // Form controls for search inputs
+  /**
+   * Saved filters for the current category.
+   */
+  protected readonly savedFiltersForCategory = computed(() => {
+    const slug = this.categorySlug();
+    if (!slug) return [];
+    return this.filterService.getSavedFiltersForCategory(slug);
+  });
+
+  // Form control for user search input
   protected readonly userSearchControl = new FormControl('', { nonNullable: true });
-  protected readonly playerSearchControl = new FormControl('', { nonNullable: true });
 
   protected readonly categorySlug = toSignal(
     this.route.paramMap.pipe(map((params) => params.get('category') as CategorySlug | null)),
@@ -171,33 +179,6 @@ export class LeaderboardComponent {
     return values.length > 0 ? Math.max(...values) : null;
   });
 
-  /**
-   * Player search value from the dropdown search input.
-   */
-  protected readonly playerSearchValue = toSignal(
-    this.playerSearchControl.valueChanges.pipe(startWith('')),
-    { initialValue: '' }
-  );
-
-  /**
-   * Player names filtered by the dropdown search input.
-   */
-  protected readonly filteredPlayerNames = computed(() => {
-    const allPlayers = this.allPlayerNames();
-    const search = this.playerSearchValue().toLowerCase().trim();
-    if (!search) return allPlayers;
-    return allPlayers.filter((p) => p.toLowerCase().includes(search));
-  });
-
-  /**
-   * Whether all of the current user's players are selected in the filter.
-   */
-  protected readonly allMyPlayersSelected = computed(() => {
-    const myPlayers = this.currentUserPickNames();
-    if (myPlayers.length === 0) return false;
-    const currentFilters = this.selectedPlayerFilters();
-    return myPlayers.every(p => currentFilters.has(p));
-  });
 
   /**
    * Standings filtered by all active filters.
@@ -383,13 +364,6 @@ export class LeaderboardComponent {
   }
 
   // Filter action methods
-  protected togglePlayerDropdown(): void {
-    this.showPlayerDropdown.update((v) => !v);
-    if (!this.showPlayerDropdown()) {
-      this.playerSearchControl.reset();
-    }
-  }
-
   protected togglePlayerFilter(playerName: string): void {
     this.selectedPlayerFilters.update((set) => {
       const newSet = new Set(set);
@@ -443,10 +417,26 @@ export class LeaderboardComponent {
 
   protected clearAllFilters(): void {
     this.userSearchControl.reset();
-    this.playerSearchControl.reset();
     this.userNameFilters.set([]);
     this.selectedPlayerFilters.set(new Set());
-    this.showPlayerDropdown.set(false);
+  }
+
+  // Saved filter handlers
+  protected onSaveFilter(data: { name: string; userNameFilters: readonly string[]; playerFilters: readonly string[] }): void {
+    const slug = this.categorySlug();
+    if (!slug) return;
+    this.filterService.saveFilter(slug, data.name, data.userNameFilters, data.playerFilters);
+  }
+
+  protected onDeleteFilter(filterId: string): void {
+    const slug = this.categorySlug();
+    if (!slug) return;
+    this.filterService.deleteFilter(slug, filterId);
+  }
+
+  protected onApplyFilter(filter: SavedFilter): void {
+    this.userNameFilters.set([...filter.userNameFilters]);
+    this.selectedPlayerFilters.set(new Set(filter.playerFilters));
   }
 
   /**

--- a/src/app/shared/ui/filter-dropdown.html
+++ b/src/app/shared/ui/filter-dropdown.html
@@ -1,0 +1,212 @@
+<!-- Filter Trigger Button -->
+<button
+  #triggerButton
+  type="button"
+  (click)="toggle()"
+  class="inline-flex items-center justify-center gap-1.5 px-2 sm:px-3 py-2 text-sm font-medium
+         border rounded-md transition-colors h-full
+         focus:outline-none focus-visible:ring-2 focus-visible:ring-club-lime"
+  [class.bg-club-sage]="hasActiveFilters()"
+  [class.border-club-green]="hasActiveFilters()"
+  [class.text-club-forest]="hasActiveFilters()"
+  [class.bg-white]="!hasActiveFilters()"
+  [class.dark:bg-gray-800]="!hasActiveFilters()"
+  [class.border-gray-300]="!hasActiveFilters()"
+  [class.dark:border-gray-600]="!hasActiveFilters()"
+  [class.text-club-forest]="!hasActiveFilters()"
+  [class.dark:text-gray-100]="!hasActiveFilters()"
+  [attr.aria-expanded]="isOpen()"
+  aria-haspopup="true"
+>
+  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+          d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
+  </svg>
+  <span class="hidden sm:inline">Filter</span>
+  @if (activeFilterCount() > 0) {
+    <span class="bg-club-forest dark:bg-club-lime text-white dark:text-club-forest text-xs px-1.5 py-0.5 rounded-full min-w-[1.25rem] text-center">
+      {{ activeFilterCount() }}
+    </span>
+  }
+</button>
+
+<!-- Dropdown Panel -->
+@if (isOpen()) {
+  <div
+    class="absolute right-0 top-full mt-2 w-72 sm:w-80 z-50
+           bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600
+           rounded-lg shadow-lg overflow-hidden"
+    role="menu"
+  >
+    <!-- Player Search -->
+    <div class="p-3 border-b border-gray-100 dark:border-gray-700">
+      <input
+        type="search"
+        [formControl]="playerSearchControl"
+        placeholder="Search players..."
+        autocomplete="off"
+        class="w-full px-3 py-2 text-sm border border-gray-200 dark:border-gray-600 rounded-md
+               bg-white dark:bg-gray-700 text-club-forest dark:text-gray-100
+               focus:outline-none focus:ring-2 focus:ring-club-lime
+               placeholder:text-gray-400"
+      />
+    </div>
+
+    <!-- Saved Filters Section -->
+    @if (hasSavedFilters()) {
+      <div class="border-b border-gray-100 dark:border-gray-700">
+        <button
+          type="button"
+          (click)="toggleSavedFiltersSection()"
+          class="w-full flex items-center justify-between px-3 py-2 text-xs font-semibold
+                 text-club-gray uppercase tracking-wide hover:bg-gray-50 dark:hover:bg-gray-700"
+        >
+          <span>Saved Filters</span>
+          <svg
+            class="w-4 h-4 transition-transform"
+            [class.rotate-180]="!showSavedFiltersSection()"
+            fill="none" stroke="currentColor" viewBox="0 0 24 24"
+          >
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+        @if (showSavedFiltersSection()) {
+          <div class="px-3 pb-3 space-y-1">
+            @for (filter of savedFilters(); track filter.id) {
+              <div
+                (click)="onApplyFilter(filter)"
+                class="flex items-center justify-between px-2 py-1.5 rounded-md cursor-pointer
+                       hover:bg-club-sage/30 dark:hover:bg-club-sage/20
+                       text-sm text-club-forest dark:text-gray-100"
+                role="menuitem"
+              >
+                <span class="truncate">{{ filter.name }}</span>
+                <button
+                  type="button"
+                  (click)="onDeleteFilter(filter.id, $event)"
+                  class="p-1 text-club-gray hover:text-club-burgundy rounded
+                         focus:outline-none focus-visible:ring-2 focus-visible:ring-club-lime"
+                  [attr.aria-label]="'Delete filter: ' + filter.name"
+                >
+                  <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20">
+                    <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
+                  </svg>
+                </button>
+              </div>
+            }
+          </div>
+        }
+      </div>
+    }
+
+    <!-- Quick Actions -->
+    @if (currentUserPickNames().length > 0) {
+      <div class="px-3 py-2 border-b border-gray-100 dark:border-gray-700">
+        <span class="block text-xs font-semibold text-club-gray uppercase tracking-wide mb-2">Quick Actions</span>
+        <button
+          type="button"
+          (click)="onSelectMyPlayers()"
+          class="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-sm font-medium
+                 border rounded-md transition-colors
+                 focus:outline-none focus-visible:ring-2 focus-visible:ring-club-lime"
+          [class.bg-club-sage]="allMyPlayersSelected()"
+          [class.border-club-green]="allMyPlayersSelected()"
+          [class.bg-white]="!allMyPlayersSelected()"
+          [class.dark:bg-gray-700]="!allMyPlayersSelected()"
+          [class.border-gray-200]="!allMyPlayersSelected()"
+          [class.dark:border-gray-600]="!allMyPlayersSelected()"
+          [title]="allMyPlayersSelected() ? 'Remove my picks from filter' : 'Select my picks'"
+        >
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+          </svg>
+          My Picks
+        </button>
+      </div>
+    }
+
+    <!-- Player List -->
+    <div class="max-h-48 overflow-y-auto">
+      <div class="px-3 py-2">
+        <span class="block text-xs font-semibold text-club-gray uppercase tracking-wide mb-2">Players</span>
+        <div class="space-y-0.5">
+          @for (player of filteredPlayerNames(); track player) {
+            <label
+              class="flex items-center gap-2 px-2 py-1.5 rounded cursor-pointer
+                     hover:bg-gray-50 dark:hover:bg-gray-700
+                     text-club-forest dark:text-gray-100"
+            >
+              <input
+                type="checkbox"
+                [checked]="isPlayerSelected(player)"
+                (change)="onPlayerToggle(player)"
+                class="rounded border-gray-300 text-club-lime focus:ring-club-lime"
+              />
+              <span class="text-sm truncate">{{ player }}</span>
+            </label>
+          }
+          @if (filteredPlayerNames().length === 0) {
+            <p class="text-sm text-club-gray text-center py-2">No players found</p>
+          }
+        </div>
+      </div>
+    </div>
+
+    <!-- Save Filter Section -->
+    @if (hasActiveFilters()) {
+      <div class="px-3 py-2 border-t border-gray-100 dark:border-gray-700 bg-gray-50 dark:bg-gray-900">
+        @if (showSaveInput()) {
+          <div class="flex gap-2">
+            <input
+              type="text"
+              [value]="newFilterName()"
+              (input)="newFilterName.set($any($event.target).value)"
+              (keydown)="onSaveInputKeydown($event)"
+              placeholder="Filter name..."
+              autocomplete="off"
+              class="flex-1 px-2 py-1.5 text-sm border border-gray-200 dark:border-gray-600 rounded-md
+                     bg-white dark:bg-gray-700 text-club-forest dark:text-gray-100
+                     focus:outline-none focus:ring-2 focus:ring-club-lime
+                     placeholder:text-gray-400"
+            />
+            <button
+              type="button"
+              (click)="onSaveFilter()"
+              [disabled]="!newFilterName().trim()"
+              class="px-2.5 py-1.5 text-sm font-medium text-white bg-club-green rounded-md
+                     hover:bg-club-forest focus:outline-none focus-visible:ring-2 focus-visible:ring-club-lime
+                     disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Save
+            </button>
+            <button
+              type="button"
+              (click)="toggleSaveInput()"
+              class="px-2 py-1.5 text-sm text-club-gray hover:text-club-forest
+                     focus:outline-none focus-visible:ring-2 focus-visible:ring-club-lime rounded-md"
+            >
+              <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
+              </svg>
+            </button>
+          </div>
+        } @else {
+          <button
+            type="button"
+            (click)="toggleSaveInput()"
+            class="w-full flex items-center justify-center gap-1.5 px-3 py-1.5 text-sm font-medium
+                   text-club-green hover:text-club-forest
+                   focus:outline-none focus-visible:ring-2 focus-visible:ring-club-lime rounded-md"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                    d="M8 7H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-3m-1 4l-3 3m0 0l-3-3m3 3V4" />
+            </svg>
+            Save current filter
+          </button>
+        }
+      </div>
+    }
+  </div>
+}

--- a/src/app/shared/ui/filter-dropdown.ts
+++ b/src/app/shared/ui/filter-dropdown.ts
@@ -1,0 +1,176 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  ElementRef,
+  HostListener,
+  inject,
+  input,
+  output,
+  signal,
+  viewChild,
+} from '@angular/core';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { Category, SavedFilter } from '../../core/models';
+
+@Component({
+  selector: 'app-filter-dropdown',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ReactiveFormsModule],
+  host: {
+    class: 'relative inline-flex flex-shrink-0',
+  },
+  templateUrl: './filter-dropdown.html',
+})
+export class FilterDropdownComponent {
+  private readonly elementRef = inject(ElementRef);
+
+  // Inputs
+  readonly category = input.required<Category>();
+  readonly allPlayerNames = input.required<readonly string[]>();
+  readonly currentUserPickNames = input.required<readonly string[]>();
+  readonly userNameFilters = input.required<readonly string[]>();
+  readonly selectedPlayerFilters = input.required<Set<string>>();
+  readonly savedFilters = input.required<readonly SavedFilter[]>();
+
+  // Outputs
+  readonly playerToggle = output<string>();
+  readonly selectMyPlayers = output<void>();
+  readonly saveFilter = output<{ name: string; userNameFilters: readonly string[]; playerFilters: readonly string[] }>();
+  readonly deleteFilter = output<string>();
+  readonly applyFilter = output<SavedFilter>();
+
+  // Internal state
+  protected readonly isOpen = signal(false);
+  protected readonly showSaveInput = signal(false);
+  protected readonly newFilterName = signal('');
+  protected readonly showSavedFiltersSection = signal(true);
+
+  // Form controls
+  protected readonly playerSearchControl = new FormControl('', { nonNullable: true });
+
+  // View children
+  private readonly triggerButton = viewChild<ElementRef<HTMLButtonElement>>('triggerButton');
+
+  // Computed
+  protected readonly activeFilterCount = computed(() => {
+    return this.userNameFilters().length + this.selectedPlayerFilters().size;
+  });
+
+  protected readonly hasActiveFilters = computed(() => {
+    return this.activeFilterCount() > 0;
+  });
+
+  protected readonly filteredPlayerNames = computed(() => {
+    const search = this.playerSearchControl.value.toLowerCase().trim();
+    const allNames = this.allPlayerNames();
+    if (!search) return allNames;
+    return allNames.filter((name) => name.toLowerCase().includes(search));
+  });
+
+  protected readonly allMyPlayersSelected = computed(() => {
+    const myPlayers = this.currentUserPickNames();
+    if (myPlayers.length === 0) return false;
+    const selectedFilters = this.selectedPlayerFilters();
+    return myPlayers.every((p) => selectedFilters.has(p));
+  });
+
+  protected readonly hasSavedFilters = computed(() => {
+    return this.savedFilters().length > 0;
+  });
+
+  protected toggle(): void {
+    this.isOpen.update((open) => !open);
+    if (!this.isOpen()) {
+      this.resetState();
+    }
+  }
+
+  protected close(): void {
+    this.isOpen.set(false);
+    this.resetState();
+    this.triggerButton()?.nativeElement.focus();
+  }
+
+  private resetState(): void {
+    this.playerSearchControl.reset();
+    this.showSaveInput.set(false);
+    this.newFilterName.set('');
+  }
+
+  protected onPlayerToggle(playerName: string): void {
+    this.playerToggle.emit(playerName);
+  }
+
+  protected onSelectMyPlayers(): void {
+    this.selectMyPlayers.emit();
+  }
+
+  protected onApplyFilter(filter: SavedFilter): void {
+    this.applyFilter.emit(filter);
+    this.close();
+  }
+
+  protected onDeleteFilter(filterId: string, event: Event): void {
+    event.stopPropagation();
+    this.deleteFilter.emit(filterId);
+  }
+
+  protected toggleSaveInput(): void {
+    this.showSaveInput.update((show) => !show);
+    if (!this.showSaveInput()) {
+      this.newFilterName.set('');
+    }
+  }
+
+  protected onSaveFilter(): void {
+    const name = this.newFilterName().trim();
+    if (!name) return;
+
+    this.saveFilter.emit({
+      name,
+      userNameFilters: this.userNameFilters(),
+      playerFilters: Array.from(this.selectedPlayerFilters()),
+    });
+
+    this.showSaveInput.set(false);
+    this.newFilterName.set('');
+  }
+
+  protected onSaveInputKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      this.onSaveFilter();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      this.toggleSaveInput();
+    }
+  }
+
+  protected toggleSavedFiltersSection(): void {
+    this.showSavedFiltersSection.update((show) => !show);
+  }
+
+  protected isPlayerSelected(playerName: string): boolean {
+    return this.selectedPlayerFilters().has(playerName);
+  }
+
+  @HostListener('document:keydown.escape')
+  onEscape(): void {
+    if (this.isOpen()) {
+      this.close();
+    }
+  }
+
+  @HostListener('document:click', ['$event'])
+  onClickOutside(event: MouseEvent): void {
+    if (!this.isOpen()) return;
+
+    const target = event.target as HTMLElement;
+    const hostElement = this.elementRef.nativeElement as HTMLElement;
+
+    if (!hostElement.contains(target)) {
+      this.close();
+    }
+  }
+}

--- a/src/app/shared/ui/index.ts
+++ b/src/app/shared/ui/index.ts
@@ -7,3 +7,4 @@ export * from './side-drawer';
 export * from './league-leaders';
 export * from './update-banner';
 export * from './feedback-modal';
+export * from './filter-dropdown';


### PR DESCRIPTION
## Summary
- Consolidate filter controls into a unified Filter dropdown with saved filter persistence
- Improve mobile layout by keeping search bar and buttons on one line with icon-only buttons on small screens

## Changes

### New Components & Services
- **FilterService** (`src/app/core/services/filter.service.ts`): Manages saved filters in localStorage per-category with SSR-safe implementation
- **FilterDropdownComponent** (`src/app/shared/ui/filter-dropdown.ts`): Unified dropdown combining player filters, "My Picks" quick action, and saved filters

### Leaderboard Refactor
- Replaced multiple filter buttons with single Filter dropdown
- Filter button shows active filter count badge
- Compare button moved inline with search bar
- All filter controls stay on one line at all screen sizes
- Buttons show icons only on mobile, icons + labels on desktop

### Saved Filters Feature
- Users can save filter combinations (user name filters + player selections)
- Saved filters persist in localStorage per-category
- Click to apply, X to delete saved filters
- Collapsible saved filters section in dropdown

## Test plan
- [ ] Verify filter controls fit on one line at 375px mobile width
- [ ] Filter and Compare buttons should be same height as search bar
- [ ] Add player filters, save with a name, refresh page - filter should persist
- [ ] Switch categories - saved filters should be category-specific
- [ ] Apply saved filter - should restore both user name and player filters
- [ ] Delete saved filter - should remove from list
- [ ] Dark mode - filter count badge should have proper contrast