### PR TITLE
implement help functionality

### DIFF
--- a/src/app/core/services/help-tour.service.ts
+++ b/src/app/core/services/help-tour.service.ts
@@ -1,0 +1,156 @@
+import { Injectable, PLATFORM_ID, inject, signal } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+
+const STORAGE_KEY = '300club_tour_completed';
+
+export interface TourStep {
+  readonly id: string;
+  readonly targetSelector: string;
+  readonly title: string;
+  readonly description: string;
+  readonly position: 'top' | 'bottom' | 'left' | 'right';
+}
+
+export const LEADERBOARD_TOUR_STEPS: readonly TourStep[] = [
+  {
+    id: 'search',
+    targetSelector: '#user-search',
+    title: 'Search Users',
+    description: 'Type a name and press Enter to filter the leaderboard. Add multiple names to see any matching users (OR logic).',
+    position: 'bottom',
+  },
+  {
+    id: 'filter',
+    targetSelector: '[data-tour="filter-button"]',
+    title: 'Filter by Players',
+    description: 'Click to filter by MLB players. Find users who picked specific players, or use "My Picks" to see who shares your selections.',
+    position: 'bottom',
+  },
+  {
+    id: 'save-filter',
+    targetSelector: '[data-tour="filter-button"]',
+    title: 'Save Filters',
+    description: 'After selecting filters, click "Save current filter" to save your combination. Saved filters persist and are category-specific.',
+    position: 'bottom',
+  },
+  {
+    id: 'compare',
+    targetSelector: '[data-tour="compare-button"]',
+    title: 'Compare Users',
+    description: 'Compare picks side-by-side between any two users. Great for seeing how your picks stack up!',
+    position: 'bottom',
+  },
+  {
+    id: 'active-filters',
+    targetSelector: '[data-tour="filter-controls"]',
+    title: 'Active Filters',
+    description: 'Your active filters appear as chips below. Click X to remove individual filters, or "Clear all" to reset.',
+    position: 'bottom',
+  },
+];
+
+@Injectable({ providedIn: 'root' })
+export class HelpTourService {
+  private readonly platformId = inject(PLATFORM_ID);
+
+  // Tour state
+  readonly isActive = signal(false);
+  readonly currentStepIndex = signal(0);
+  readonly steps = signal<readonly TourStep[]>([]);
+
+  private get isBrowser(): boolean {
+    return isPlatformBrowser(this.platformId);
+  }
+
+  /**
+   * Check if the user has completed the tour before.
+   */
+  hasCompletedTour(): boolean {
+    if (!this.isBrowser) return true;
+    return localStorage.getItem(STORAGE_KEY) === 'true';
+  }
+
+  /**
+   * Start the tour with the given steps.
+   */
+  startTour(steps: readonly TourStep[]): void {
+    this.steps.set(steps);
+    this.currentStepIndex.set(0);
+    this.isActive.set(true);
+  }
+
+  /**
+   * Start the leaderboard filter tour.
+   */
+  startLeaderboardTour(): void {
+    this.startTour(LEADERBOARD_TOUR_STEPS);
+  }
+
+  /**
+   * Move to the next step.
+   */
+  nextStep(): void {
+    const current = this.currentStepIndex();
+    const total = this.steps().length;
+    if (current < total - 1) {
+      this.currentStepIndex.set(current + 1);
+    } else {
+      this.completeTour();
+    }
+  }
+
+  /**
+   * Move to the previous step.
+   */
+  previousStep(): void {
+    const current = this.currentStepIndex();
+    if (current > 0) {
+      this.currentStepIndex.set(current - 1);
+    }
+  }
+
+  /**
+   * Skip/close the tour without marking as complete.
+   */
+  closeTour(): void {
+    this.isActive.set(false);
+    this.currentStepIndex.set(0);
+    this.steps.set([]);
+  }
+
+  /**
+   * Complete the tour and mark as seen.
+   */
+  completeTour(): void {
+    this.closeTour();
+    if (this.isBrowser) {
+      try {
+        localStorage.setItem(STORAGE_KEY, 'true');
+      } catch {
+        // Ignore storage errors
+      }
+    }
+  }
+
+  /**
+   * Reset the tour completion flag (for testing or re-showing).
+   */
+  resetTourCompletion(): void {
+    if (this.isBrowser) {
+      try {
+        localStorage.removeItem(STORAGE_KEY);
+      } catch {
+        // Ignore storage errors
+      }
+    }
+  }
+
+  /**
+   * Get the current step.
+   */
+  get currentStep(): TourStep | null {
+    const steps = this.steps();
+    const index = this.currentStepIndex();
+    return steps[index] ?? null;
+  }
+}

--- a/src/app/core/services/index.ts
+++ b/src/app/core/services/index.ts
@@ -3,3 +3,4 @@ export * from './leaderboard.service';
 export * from './theme.service';
 export * from './update.service';
 export * from './filter.service';
+export * from './help-tour.service';

--- a/src/app/features/leaderboard/leaderboard.html
+++ b/src/app/features/leaderboard/leaderboard.html
@@ -88,7 +88,7 @@
           }
 
           <!-- Filter Section -->
-          <div class="mb-4 space-y-3">
+          <div class="mb-4 space-y-3" data-tour="filter-controls">
             <!-- Filter Controls Row -->
             <div class="flex flex-row items-stretch gap-2">
               <!-- User Name Search -->
@@ -116,6 +116,7 @@
               <!-- Filter Dropdown (Player filters + My Picks + Saved filters) -->
               @if (cat.slug !== 'dimaggio') {
                 <app-filter-dropdown
+                  data-tour="filter-button"
                   [category]="cat"
                   [allPlayerNames]="allPlayerNames()"
                   [currentUserPickNames]="currentUserPickNames()"
@@ -132,6 +133,7 @@
 
               <!-- Compare Button -->
               <button type="button" (click)="openComparisonModal()"
+                data-tour="compare-button"
                 class="inline-flex items-center justify-center gap-1.5 px-2 sm:px-3 py-2 text-sm font-medium
                        bg-club-sage/50 text-club-forest border border-club-sage rounded-md
                        hover:bg-club-sage focus:outline-none focus-visible:ring-2 focus-visible:ring-club-lime
@@ -141,6 +143,21 @@
                         d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
                 </svg>
                 <span class="hidden sm:inline">Compare</span>
+              </button>
+
+              <!-- Help Tour Button -->
+              <button type="button" (click)="startTour()"
+                class="inline-flex items-center justify-center p-2 text-sm font-medium
+                       text-club-gray hover:text-club-forest dark:hover:text-white
+                       hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md
+                       focus:outline-none focus-visible:ring-2 focus-visible:ring-club-lime
+                       flex-shrink-0"
+                title="How to use filters"
+                aria-label="Show filter help tour">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                        d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
               </button>
             </div>
 
@@ -635,3 +652,6 @@
         (close)="closeComparisonModal()"
       />
     }
+
+    <!-- Help Tour Overlay -->
+    <app-help-tour />

--- a/src/app/features/leaderboard/leaderboard.ts
+++ b/src/app/features/leaderboard/leaderboard.ts
@@ -4,13 +4,13 @@ import { ReactiveFormsModule, FormControl } from '@angular/forms';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { map } from 'rxjs';
 import { CategorySlug, getCategoryBySlug, MlbLeader, SavedFilter, User, UserStanding } from '../../core/models';
-import { FilterService, LeaderboardService, UserService } from '../../core/services';
-import { FilterDropdownComponent, LeagueLeadersComponent, LoadingSpinnerComponent, RulesPopoverComponent, UserComparisonModalComponent } from '../../shared/ui';
+import { FilterService, HelpTourService, LeaderboardService, UserService } from '../../core/services';
+import { FilterDropdownComponent, HelpTourComponent, LeagueLeadersComponent, LoadingSpinnerComponent, RulesPopoverComponent, UserComparisonModalComponent } from '../../shared/ui';
 
 @Component({
   selector: 'app-leaderboard',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [RouterLink, ReactiveFormsModule, FilterDropdownComponent, LeagueLeadersComponent, LoadingSpinnerComponent, RulesPopoverComponent, UserComparisonModalComponent],
+  imports: [RouterLink, ReactiveFormsModule, FilterDropdownComponent, HelpTourComponent, LeagueLeadersComponent, LoadingSpinnerComponent, RulesPopoverComponent, UserComparisonModalComponent],
   templateUrl: './leaderboard.html',
 })
 export class LeaderboardComponent {
@@ -18,6 +18,7 @@ export class LeaderboardComponent {
   private readonly leaderboardService = inject(LeaderboardService);
   private readonly userService = inject(UserService);
   private readonly filterService = inject(FilterService);
+  private readonly helpTourService = inject(HelpTourService);
 
   protected readonly isLoading = signal(false);
   protected readonly error = signal<string | null>(null);
@@ -480,5 +481,10 @@ export class LeaderboardComponent {
 
     // Check that ALL selected players are in the user's picks
     return normalizedPlayers.every((player) => userPickNames.includes(player));
+  }
+
+  // Help tour
+  protected startTour(): void {
+    this.helpTourService.startLeaderboardTour();
   }
 }

--- a/src/app/shared/ui/help-tour.html
+++ b/src/app/shared/ui/help-tour.html
@@ -1,0 +1,134 @@
+@if (isActive()) {
+  <!-- Backdrop overlay -->
+  <div
+    class="fixed inset-0 z-[998] bg-black/60 transition-opacity"
+    (click)="onClose()"
+    aria-hidden="true"
+  ></div>
+
+  <!-- Spotlight cutout -->
+  @if (spotlightPosition(); as spotlight) {
+    <div
+      class="fixed z-[999] rounded-lg pointer-events-none"
+      [style.top.px]="spotlight.top"
+      [style.left.px]="spotlight.left"
+      [style.width.px]="spotlight.width"
+      [style.height.px]="spotlight.height"
+      style="box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.6);"
+      aria-hidden="true"
+    >
+      <!-- Animated ring around spotlight -->
+      <div class="absolute inset-0 rounded-lg border-2 border-club-lime animate-pulse"></div>
+    </div>
+  }
+
+  <!-- Tooltip -->
+  @if (currentStep(); as step) {
+    @if (tooltipPosition(); as pos) {
+      <div
+        class="fixed z-[1000] w-80 bg-white dark:bg-gray-800 rounded-lg shadow-xl
+               border border-gray-200 dark:border-gray-700"
+        [style.top]="pos.top"
+        [style.left]="pos.left"
+        role="dialog"
+        aria-modal="true"
+        [attr.aria-labelledby]="'tour-title-' + step.id"
+      >
+        <!-- Arrow -->
+        <div
+          class="absolute w-3 h-3 bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 transform rotate-45"
+          [class.-top-1.5]="pos.arrowPosition === 'top'"
+          [class.left-1/2]="pos.arrowPosition === 'top' || pos.arrowPosition === 'bottom'"
+          [class.-translate-x-1/2]="pos.arrowPosition === 'top' || pos.arrowPosition === 'bottom'"
+          [class.border-t]="pos.arrowPosition === 'top'"
+          [class.border-l]="pos.arrowPosition === 'top'"
+          [class.-bottom-1.5]="pos.arrowPosition === 'bottom'"
+          [class.border-b]="pos.arrowPosition === 'bottom'"
+          [class.border-r]="pos.arrowPosition === 'bottom'"
+          [class.-left-1.5]="pos.arrowPosition === 'left'"
+          [class.top-1/2]="pos.arrowPosition === 'left' || pos.arrowPosition === 'right'"
+          [class.-translate-y-1/2]="pos.arrowPosition === 'left' || pos.arrowPosition === 'right'"
+          [class.border-t-left]="pos.arrowPosition === 'left'"
+          [class.border-b-left]="pos.arrowPosition === 'left'"
+          [class.-right-1.5]="pos.arrowPosition === 'right'"
+          aria-hidden="true"
+        ></div>
+
+        <!-- Content -->
+        <div class="p-4">
+          <!-- Header with close button -->
+          <div class="flex items-start justify-between mb-2">
+            <h3
+              [id]="'tour-title-' + step.id"
+              class="text-lg font-semibold text-club-forest dark:text-white"
+            >
+              {{ step.title }}
+            </h3>
+            <button
+              type="button"
+              (click)="onClose()"
+              class="p-1 text-club-gray hover:text-club-forest dark:hover:text-white
+                     rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-club-lime"
+              aria-label="Close tour"
+            >
+              <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
+              </svg>
+            </button>
+          </div>
+
+          <!-- Description -->
+          <p class="text-sm text-club-gray dark:text-gray-300 mb-4">
+            {{ step.description }}
+          </p>
+
+          <!-- Footer with navigation -->
+          <div class="flex items-center justify-between">
+            <!-- Progress -->
+            <span class="text-xs text-club-gray">
+              {{ stepProgress() }}
+            </span>
+
+            <!-- Navigation buttons -->
+            <div class="flex gap-2">
+              @if (!isFirstStep()) {
+                <button
+                  type="button"
+                  (click)="onPrevious()"
+                  class="px-3 py-1.5 text-sm font-medium text-club-forest dark:text-gray-200
+                         hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md
+                         focus:outline-none focus-visible:ring-2 focus-visible:ring-club-lime"
+                >
+                  Back
+                </button>
+              }
+              @if (isLastStep()) {
+                <button
+                  type="button"
+                  (click)="onComplete()"
+                  class="px-3 py-1.5 text-sm font-medium text-white bg-club-green
+                         hover:bg-club-forest dark:bg-club-sage dark:text-club-forest
+                         dark:hover:bg-club-lime rounded-md
+                         focus:outline-none focus-visible:ring-2 focus-visible:ring-club-lime"
+                >
+                  Got it!
+                </button>
+              } @else {
+                <button
+                  type="button"
+                  (click)="onNext()"
+                  class="px-3 py-1.5 text-sm font-medium text-white bg-club-green
+                         hover:bg-club-forest dark:bg-club-sage dark:text-club-forest
+                         dark:hover:bg-club-lime rounded-md
+                         focus:outline-none focus-visible:ring-2 focus-visible:ring-club-lime"
+                >
+                  Next
+                </button>
+              }
+            </div>
+          </div>
+        </div>
+      </div>
+    }
+  }
+}

--- a/src/app/shared/ui/help-tour.ts
+++ b/src/app/shared/ui/help-tour.ts
@@ -1,0 +1,166 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  HostListener,
+  inject,
+  signal,
+} from '@angular/core';
+import { HelpTourService, TourStep } from '../../core/services/help-tour.service';
+
+interface TooltipPosition {
+  top: string;
+  left: string;
+  arrowPosition: 'top' | 'bottom' | 'left' | 'right';
+}
+
+interface SpotlightPosition {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+@Component({
+  selector: 'app-help-tour',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './help-tour.html',
+})
+export class HelpTourComponent {
+  protected readonly tourService = inject(HelpTourService);
+
+  protected readonly spotlightPosition = signal<SpotlightPosition | null>(null);
+  protected readonly tooltipPosition = signal<TooltipPosition | null>(null);
+
+  protected readonly isActive = this.tourService.isActive;
+  protected readonly currentStepIndex = this.tourService.currentStepIndex;
+  protected readonly steps = this.tourService.steps;
+
+  protected readonly currentStep = computed(() => {
+    const steps = this.steps();
+    const index = this.currentStepIndex();
+    return steps[index] ?? null;
+  });
+
+  protected readonly isFirstStep = computed(() => this.currentStepIndex() === 0);
+  protected readonly isLastStep = computed(() => {
+    const steps = this.steps();
+    return this.currentStepIndex() === steps.length - 1;
+  });
+
+  protected readonly stepProgress = computed(() => {
+    const total = this.steps().length;
+    const current = this.currentStepIndex() + 1;
+    return `${current} of ${total}`;
+  });
+
+  constructor() {
+    // Update positions when step changes
+    effect(() => {
+      const step = this.currentStep();
+      const isActive = this.isActive();
+      if (isActive && step) {
+        // Small delay to ensure DOM is ready
+        setTimeout(() => this.updatePositions(step), 50);
+      }
+    });
+  }
+
+  private updatePositions(step: TourStep): void {
+    const target = document.querySelector(step.targetSelector);
+    if (!target) {
+      // If target not found, skip to next step or close
+      console.warn(`Tour target not found: ${step.targetSelector}`);
+      return;
+    }
+
+    const rect = target.getBoundingClientRect();
+    const padding = 8;
+
+    // Spotlight position
+    this.spotlightPosition.set({
+      top: rect.top - padding + window.scrollY,
+      left: rect.left - padding,
+      width: rect.width + padding * 2,
+      height: rect.height + padding * 2,
+    });
+
+    // Tooltip position
+    const tooltipWidth = 320;
+    const tooltipHeight = 180; // Approximate
+    const gap = 16;
+
+    let top: number;
+    let left: number;
+    let arrowPosition: 'top' | 'bottom' | 'left' | 'right';
+
+    switch (step.position) {
+      case 'bottom':
+        top = rect.bottom + gap + window.scrollY;
+        left = rect.left + rect.width / 2 - tooltipWidth / 2;
+        arrowPosition = 'top';
+        break;
+      case 'top':
+        top = rect.top - tooltipHeight - gap + window.scrollY;
+        left = rect.left + rect.width / 2 - tooltipWidth / 2;
+        arrowPosition = 'bottom';
+        break;
+      case 'left':
+        top = rect.top + rect.height / 2 - tooltipHeight / 2 + window.scrollY;
+        left = rect.left - tooltipWidth - gap;
+        arrowPosition = 'right';
+        break;
+      case 'right':
+        top = rect.top + rect.height / 2 - tooltipHeight / 2 + window.scrollY;
+        left = rect.right + gap;
+        arrowPosition = 'left';
+        break;
+    }
+
+    // Keep tooltip within viewport
+    const viewportWidth = window.innerWidth;
+    if (left < 16) left = 16;
+    if (left + tooltipWidth > viewportWidth - 16) {
+      left = viewportWidth - tooltipWidth - 16;
+    }
+
+    this.tooltipPosition.set({
+      top: `${top}px`,
+      left: `${left}px`,
+      arrowPosition,
+    });
+  }
+
+  protected onNext(): void {
+    this.tourService.nextStep();
+  }
+
+  protected onPrevious(): void {
+    this.tourService.previousStep();
+  }
+
+  protected onClose(): void {
+    this.tourService.closeTour();
+  }
+
+  protected onComplete(): void {
+    this.tourService.completeTour();
+  }
+
+  @HostListener('document:keydown.escape')
+  onEscape(): void {
+    if (this.isActive()) {
+      this.onClose();
+    }
+  }
+
+  @HostListener('window:resize')
+  @HostListener('window:scroll')
+  onViewportChange(): void {
+    const step = this.currentStep();
+    if (this.isActive() && step) {
+      this.updatePositions(step);
+    }
+  }
+}

--- a/src/app/shared/ui/index.ts
+++ b/src/app/shared/ui/index.ts
@@ -8,3 +8,4 @@ export * from './league-leaders';
 export * from './update-banner';
 export * from './feedback-modal';
 export * from './filter-dropdown';
+export * from './help-tour';


### PR DESCRIPTION
## Summary
Add an interactive guided tour to help users understand the leaderboard filter controls.

## Changes

### New Components & Services
- **HelpTourService** (`src/app/core/services/help-tour.service.ts`): Manages tour state, step navigation, and localStorage persistence for tour completion
- **HelpTourComponent** (`src/app/shared/ui/help-tour.ts`): Renders overlay with spotlight effect and positioned tooltips

### Tour Features
- Help button (?) added next to Compare button in filter controls
- Semi-transparent backdrop with spotlight "cutout" highlighting each feature
- Animated green ring around highlighted elements
- Positioned tooltips with title, description, and navigation
- 5 tour steps: Search, Filter, Save Filter, Compare, Active Filters
- Back/Next navigation with step progress indicator
- Keyboard support (Escape to close)
- Viewport-aware tooltip positioning
- Tour completion persisted to localStorage

### Dark Mode Support
- Tooltip styled for both light and dark themes
- Next/Got it buttons use sage green base with lime hover in dark mode

## Test plan
- [x] Click (?) button - tour overlay should appear
- [x] Spotlight should highlight search bar with animated ring
- [x] Click Next - should advance through all 5 steps
- [x] Click Back - should return to previous step
- [x] Press Escape - should close tour
- [x] Click backdrop - should close tour
- [x] Complete tour, refresh page, click (?) - tour should still work (can restart)
- [x] Test in dark mode - buttons should be readable with proper contrast
- [x] Resize window during tour - spotlight and tooltip should reposition

---

🤖 Generated with [Claude Code](https://claude.ai/code)