### PR TITLE
upgrade actions node version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,11 @@ on:
     branches: [main]
   workflow_dispatch:
 
+env:
+  # Force GitHub Actions to use Node.js 24 instead of deprecated Node.js 20
+  # See: https://github.blog/changelog/2024-05-17-updated-dates-for-actions-runner-using-node20-instead-of-node16-by-default/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build-and-deploy:
     name: Build and Deploy to Lightsail
@@ -57,7 +62,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       # ------------------------------------------------------------------

--- a/claude.md
+++ b/claude.md
@@ -18,7 +18,7 @@ A read-only Angular frontend for 300 Club, a baseball competition leaderboard ap
 | TypeScript | 5.9 | Strict mode enabled |
 | Tailwind CSS | 4.x | Via @tailwindcss/postcss |
 | RxJS | 7.8 | For HTTP, NO NgRx |
-| Node | 20+ | Package manager: npm 11.6.2 |
+| Node | 22+ | Package manager: npm 11.6.2 |
 
 ## Backend API
 


### PR DESCRIPTION
Addressing this warning found when running action to deploy code:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-node@v4. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/